### PR TITLE
link was broken

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,4 +35,4 @@ the edition on the configured forge:
 
 For now, only GitLab, GitHub and Pagure.io hosted services are supported.
 
-If you want to add more, please see the hash FORGES in [extension.rb](blob/master/lib/middleman-edit-forge/extension.rb)
+If you want to add more, please see the hash FORGES in [extension.rb](lib/middleman-edit-forge/extension.rb)


### PR DESCRIPTION
maybe linking to the raw file doesnt work anymore? This links to the file inside github viewer, which works for the purpose.
